### PR TITLE
Add autoconf port

### DIFF
--- a/autoconf/package.sh
+++ b/autoconf/package.sh
@@ -1,0 +1,5 @@
+#!/opt/local/bin/mksh ../.port.sh
+port=autoconf
+version=2.69
+useconfigure=true
+files="http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz autoconf-2.69.tar.gz 562471cbcb0dd0fa42a76665acf0dbb68479b78a"

--- a/autoconf/package.sh
+++ b/autoconf/package.sh
@@ -3,3 +3,4 @@ port=autoconf
 version=2.69
 useconfigure=true
 files="http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz autoconf-2.69.tar.gz 562471cbcb0dd0fa42a76665acf0dbb68479b78a"
+depends=m4


### PR DESCRIPTION
* Adds autoconf v2.69 port.
* Depends on m4 (see other PR).
* Tested on Octane with Irix 6.5
* Needs testing on 32bit Irix.