### PR TITLE
Add libptytty - a dependency of urxvt

### DIFF
--- a/libptytty/package.sh
+++ b/libptytty/package.sh
@@ -1,0 +1,15 @@
+#!/opt/local/bin/mksh ../.port.sh
+port=libptytty
+version=1.8
+useconfigure=true
+files="http://dist.schmorp.de/libptytty/libptytty-1.8.tar.gz libptytty-1.8.tar.gz f20959a80b8ec6b951b07beddccaf045c8a932f0"
+patchlevel=1
+depends="libtool autoconf"
+
+configure() {
+	runwd autoupdate
+	runwd libtoolize --automake --force --copy
+	runwd autoreconf --install
+	runwd automake
+	runwd ./configure --prefix="$prefix"	
+}

--- a/libptytty/patches/libptytty18_001
+++ b/libptytty/patches/libptytty18_001
@@ -1,0 +1,41 @@
+--- a/ptytty.m4	Mon May 11 17:24:03 CDT 2015
++++ b/ptytty.m4	Fri Aug 23 12:31:34 CDT 2019
+@@ -2,7 +2,7 @@
+ [AC_CACHE_CHECK(for a fallback location of $1, pt_cv_path_$1, [
+ if test "$cross_compiling" != yes; then
+   for file in $3; do
+-    if test -f "$file"; then
++    if test -e "$file"; then
+       pt_cv_path_$1=$file
+       break
+     fi
+@@ -204,6 +204,9 @@
+ 
+ AC_CACHE_CHECK(for unix-compliant filehandle passing ability, pt_cv_can_pass_fds,
+ [AC_LINK_IFELSE([AC_LANG_PROGRAM([[
++#ifdef __sgi
++#define _XOPEN_SOURCE
++#endif
+ #include <stddef.h> // broken bsds (is that redundant?) need this
+ #include <sys/types.h>
+ #include <sys/socket.h>
+@@ -210,8 +213,8 @@
+ #include <sys/uio.h>
+ ]], [[
+ {
+-  msghdr msg;
+-  iovec iov;
++  struct msghdr msg;
++  struct iovec iov;
+   char buf [100];
+   char data = 0;
+ 
+@@ -223,7 +226,7 @@
+   msg.msg_control    = buf;
+   msg.msg_controllen = sizeof buf;
+ 
+-  cmsghdr *cmsg = CMSG_FIRSTHDR (&msg);
++  struct cmsghdr *cmsg = CMSG_FIRSTHDR (&msg);
+   cmsg->cmsg_level = SOL_SOCKET;
+   cmsg->cmsg_type  = SCM_RIGHTS;
+   cmsg->cmsg_len   = 100;

--- a/libptytty/patches/libptytty18_002
+++ b/libptytty/patches/libptytty18_002
@@ -1,0 +1,22 @@
+--- a/src/fdpass.C	Sun Nov 16 06:22:34 CST 2014
++++ b/src/fdpass.C	Fri Aug 23 12:19:20 CDT 2019
+@@ -20,6 +20,10 @@
+  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+  *----------------------------------------------------------------------*/
+ 
++#ifdef __sgi
++#define _XOPEN_SOURCE
++#endif
++
+ #include "config.h"
+ 
+ #include <stddef.h> // needed by broken bsds for NULL used in sys/uio.h
+@@ -60,7 +64,7 @@
+   msg.msg_namelen    = 0;
+   msg.msg_iov        = &iov;
+   msg.msg_iovlen     = 1;
+-  msg.msg_control    = buf;
++  msg.msg_control    = (char*)buf;
+   msg.msg_controllen = CMSG_SPACE (sizeof (int));
+ 
+   cmsg = CMSG_FIRSTHDR (&msg);


### PR DESCRIPTION
This library is an offspring of rxvt-unicode, which depends on it.
Some minor patches needed, but mostly painless:
* On Irix, lastlog is a directory, not a file ; changed test -f to test -e to let configure check pass.
* #define _XOPEN_SOURCE required to make sys/socket.h define the right things.
* Some minor stuff like declaring structs with the struct keyword and missing casts to make the compiler happy.


