### PR TITLE
bootstrap.sh: Don't interpolate $LD_LIBRARYN32_PATH

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,7 +37,6 @@ inst -A -f /tmp/gnuchain
 ln -sf /opt/local/binutils-dev/bin /opt/local/gcc-8.2.0/mips-sgi-irix6.5/bin
 echo "Done! Removing temporary files."
 rm -r /tmp/gcc4 /tmp/gnuchain /optlocal.tar
-echo "When working with irixports, you should make sure that GCC's lib32 directory is in LD_LIBRARYN32_PATH."
-echo "In a bourne-like shell, you can put something like this to your profile:"
+echo "When working with irixports, you should make sure that GCC's lib32 directory is in LD_LIBRARYN32_PATH. In a bourne-like shell, you can add something like this to your profile:"
 echo
 echo '    export LD_LIBRARYN32_PATH=$LD_LIBRARYN32_PATH:/opt/local/gcc-4.7.4/lib32'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,4 +37,7 @@ inst -A -f /tmp/gnuchain
 ln -sf /opt/local/binutils-dev/bin /opt/local/gcc-8.2.0/mips-sgi-irix6.5/bin
 echo "Done! Removing temporary files."
 rm -r /tmp/gcc4 /tmp/gnuchain /optlocal.tar
-echo "When working with irixports, you should make sure that GCC's lib32 directory is in LD_LIBRARYN32_PATH. In a bourne-like shell, you can put something like export LD_LIBRARYN32_PATH=$LD_LIBRARYN32_PATH:/opt/local/gcc-4.7.4/lib32 in your profile."
+echo "When working with irixports, you should make sure that GCC's lib32 directory is in LD_LIBRARYN32_PATH."
+echo "In a bourne-like shell, you can put something like this to your profile:"
+echo
+echo '    export LD_LIBRARYN32_PATH=$LD_LIBRARYN32_PATH:/opt/local/gcc-4.7.4/lib32'


### PR DESCRIPTION
The caveat message at the end of `bootstrap.sh` interpolates `$LD_LIBRARYN32_PATH` which at least for me resulted in just empty string. It suggested using
`export LD_LIBRARYN32_PATH=:/opt/local/gcc-4.7.4/lib32` While not technically wrong or broken, I don't believe this was the intent.

This change ensures it is output as a string literal.

I also broke up the message onto a couple lines for readability and to make what needs to be done a bit more clear.

New message:

```
When working with irixports, you should make sure that GCC's lib32 directory is in LD_LIBRARYN32_PATH.
In a bourne-like shell, you can put something like this to your profile:

    export LD_LIBRARYN32_PATH=$LD_LIBRARYN32_PATH:/opt/local/gcc-4.7.4/lib32
```